### PR TITLE
Apply CC BY-SA-4 license to dictionary contents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,6 @@ Contributions are welcome, either in the form of issues for discussing whether s
 
 # License
 
-The actual content of this dictionary, currently in the file [rust-tropes.md](rust-tropes.md) but not bound by this representation or path in the repository, is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License. This license shall be transferred with any eventual change of formatting or representation of the same information.
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>
 
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+The actual content of this dictionary, currently in the file [rust-tropes.md](rust-tropes.md) but not bound by this representation or path in the repository, is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>. This license shall be transferred with any eventual change of formatting or representation of the same information.

--- a/readme.md
+++ b/readme.md
@@ -7,3 +7,9 @@ This project is an initiative to write a dictionary of expressions and other jar
 ## Contributing
 
 Contributions are welcome, either in the form of issues for discussing whether something _is_ a trope worth having here, or pull requests proposing new entries or improvements to existing entries. Please prefer one pull request per entry, so that they can be reviewed individually.
+
+# License
+
+The actual content of this dictionary, currently in the file [rust-tropes.md](rust-tropes.md) but not bound by this representation or path in the repository, is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License. This license shall be transferred with any eventual change of formatting or representation of the same information.
+
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.


### PR DESCRIPTION
The idea is to apply the [Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) ](https://creativecommons.org/licenses/by-sa/4.0/) to the contents of this project. They are currently in a Markdown, but this could change in the future, so that it can be indexed and better presented by a static website. As such, my intent is to:

- apply this license only to the contents of the dictionary, leaving any potential static site generation code with another license in the future;
- keep this license to the contents of this dictionary, even if its format or source location changes. Today we have a .md file, in the future it could be a .json, .yaml, .rs, ...

